### PR TITLE
remove results_.resize in SpMSpVModule::send_results_device_to_host

### DIFF
--- a/graphlily/module/spmspv_module.h
+++ b/graphlily/module/spmspv_module.h
@@ -210,8 +210,6 @@ public:
     aligned_sparse_vec_t send_vector_device_to_host() {
         this->command_queue_.enqueueMigrateMemObjects({this->vector_buf}, CL_MIGRATE_MEM_OBJECT_HOST);
         this->command_queue_.finish();
-        // truncate useless data
-        this->vector_.resize(this->vector_[0].index + 1);
         return this->vector_;
     }
 
@@ -232,9 +230,6 @@ public:
     aligned_sparse_vec_t send_results_device_to_host() {
         this->command_queue_.enqueueMigrateMemObjects({this->results_buf}, CL_MIGRATE_MEM_OBJECT_HOST);
         this->command_queue_.finish();
-        // truncate useless data
-        this->results_.resize(this->results_[0].index + 1);
-        // std::cout << "INFO: [Module SpMSpV - collect result] result collected." << std::endl << std::flush;
         return this->results_;
     }
 


### PR DESCRIPTION
An error occurs when we call `BFS::pull_push` multiple times on the same dataset with different source vertices. This is due to the `results_.resize` function call in `SpMSpVModule::send_results_device_to_host`. Specifically, the following piece of code causes wrong results:

```c++
this->command_queue_.enqueueMigrateMemObjects({this->results_buf}, CL_MIGRATE_MEM_OBJECT_HOST);
this->command_queue_.finish();
this->results_.resize(a_small_number);
return this->results_;

this->command_queue_.enqueueMigrateMemObjects({this->results_buf}, CL_MIGRATE_MEM_OBJECT_HOST);
this->command_queue_.finish();
this->results_.resize(a_large_number);
return this->results_;  // wrong because this->results_ has been resized to a small number
```

This PR solves the bug by removing `results_.resize`, which is indeed not useful at all. I don't remember why we do it; maybe it makes it clear that the results vector is sparse with a size determined at run time.

@zzczzc20 Zhongchun, please check if this PR solves the bug you encountered and then merge it.
